### PR TITLE
chore: get branch that triggered workflow from context

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -37,7 +37,6 @@ jobs:
         uses: ./
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          branchName: ${{ github.ref_name }}
           cloudflareProjectName: test-publish-to-cloudflare
           cloudflareApiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflareAccountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -3,20 +3,21 @@
 > This is a Github action that runs the unit tests of a repository, generates a test coverage report, uploads the report to Cloudflare Pages and comments the results on available pull requests.
 
 ## Requirements:
+
 1. A Javascript repository, hosted on Github, using Jest for unit testing
 2. A Cloudflare account with access to Cloudflare Pages and:
-    - A Cloudflare API Token
-    - The Cloudflare Account ID
-    - A Cloudflare Pages project (to upload coverage reports)
+   - A Cloudflare API Token
+   - The Cloudflare Account ID
+   - A Cloudflare Pages project (to upload coverage reports)
 
 ## How to use:
+
 In your repository, add the following step to your branch pushes workflow:
 
 ```yaml
     - name: Test & Publish to Cloudflare 🧪
         uses: carlosdevpereira/test-publish-to-cloudflare@v1
         with:
-          branchName: ${{ github.ref_name }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cloudflareProjectName: THE_NAME_OF_YOUR_CLOUDFLARE_PROJECT
           cloudflareApiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -50,7 +51,6 @@ jobs:
       - name: Test & Publish to Cloudflare 🧪
         uses: carlosdevpereira/test-publish-to-cloudflare@v1
         with:
-          branchName: ${{ github.ref_name }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cloudflareProjectName: THE_NAME_OF_YOUR_CLOUDFLARE_PROJECT
           cloudflareApiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -64,8 +64,6 @@ jobs:
 ### Expected parameters:
 
 - **framework**: Defines which testing framework this action should use to run the tests of your repository. For now the only valid value is `jest` but `vitest` support will be added soon.
-
-- **branchName**: The name of the branch that triggered the workflow. By default you may want the value of this parameter to be equal to the value of the context variable `github.ref_name`.
 
 - **githubToken**: The token that this action should use to authenticate requests to the Github API.
 

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,6 @@ inputs:
   githubToken:
     description: "The github token that will be used to comment the results on available pull requests."
     required: true
-  branchName:
-    description: "The name of the branch that triggered the workflow."
-    required: true
   cloudflareProjectName:
     description: "The name of the project on Cloudflare that will receive the coverage report."
     required: true

--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,7 @@ async function run() {
         }),
       },
       github: {
-        branch: core.getInput('branchName', {
-          required: true,
-        }),
+        branch: github.context.ref,
         token: core.getInput('githubToken', {
           required: true,
         }),

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ const GithubAction = require('./Action');
 
 async function run() {
   try {
+    core.info('context:');
+    core.info(JSON.stringify(github.context));
     const Action = new GithubAction(github.context, {
       cloudflare: {
         accountId: core.getInput('cloudflareAccountId', {

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,6 @@ const GithubAction = require('./Action');
 
 async function run() {
   try {
-    core.info('context:');
-    core.info(JSON.stringify(github.context));
     const Action = new GithubAction(github.context, {
       cloudflare: {
         accountId: core.getInput('cloudflareAccountId', {
@@ -20,7 +18,7 @@ async function run() {
         }),
       },
       github: {
-        branch: github.context.ref,
+        branch: github.context.ref.replace('refs/heads/', ''),
         token: core.getInput('githubToken', {
           required: true,
         }),

--- a/tests/fixtures/github-action-context.json
+++ b/tests/fixtures/github-action-context.json
@@ -1,4 +1,5 @@
 {
+  "ref": "github-branch-name",
   "sha": "13c988d4f15e06bcdd0b0af290086a3079cdadb0",
   "payload": {
     "repository": {

--- a/tests/jest-setup.js
+++ b/tests/jest-setup.js
@@ -1,3 +1,9 @@
 // Setup global mocks
 const mockGithubActionsCore = require('@tests/mocks/github-actions-core');
 jest.mock('@actions/core', () => mockGithubActionsCore);
+
+const githubActionContextFixture = require('@tests/fixtures/github-action-context');
+jest.mock('@actions/github', () => ({
+  context: githubActionContextFixture,
+  getOctokit: jest.fn()
+}));

--- a/tests/mocks/@action-github.js
+++ b/tests/mocks/@action-github.js
@@ -1,0 +1,5 @@
+module.exports = {
+  context: {
+    ref: 'github-branch-name'
+  }
+};

--- a/tests/unit/Action.spec.js
+++ b/tests/unit/Action.spec.js
@@ -11,7 +11,6 @@ const Repository = require('@/Repository');
 
 const githubActionContextFixture = require('@tests/fixtures/github-action-context');
 const githubActionConfigFixture = require('@tests/fixtures/github-action-config');
-const pullRequestsFixture = require('@tests/fixtures/pull-requests');
 
 describe('Action', () => {
   const GithubAction = require('@/Action');

--- a/tests/unit/index.spec.js
+++ b/tests/unit/index.spec.js
@@ -1,4 +1,5 @@
 const core = require('@actions/core');
+const context = require('@tests/fixtures/github-action-context');
 
 describe('Action Setup -> Happy path', () => {
   const mockAction = require('@tests/mocks/action');
@@ -8,7 +9,6 @@ describe('Action Setup -> Happy path', () => {
 
   const setupEnvironmentVariables = () => {
     process.env.INPUT_GITHUBTOKEN = '1234';
-    process.env.INPUT_BRANCHNAME = 'master';
     process.env.INPUT_CLOUDFLAREPROJECTNAME = 'my-cloudflare-project';
     process.env.INPUT_CLOUDFLAREAPITOKEN = 'cloudflare-api-token';
     process.env.INPUT_CLOUDFLAREACCOUNTID = 'cloudflare-account-id';
@@ -23,12 +23,6 @@ describe('Action Setup -> Happy path', () => {
 
     it('checks if a github token was defined', () => {
       expect(core.getInput).toHaveBeenCalledWith('githubToken', {
-        required: true,
-      });
-    });
-
-    it('checks if the head branch name was defined', () => {
-      expect(core.getInput).toHaveBeenCalledWith('branchName', {
         required: true,
       });
     });
@@ -61,6 +55,11 @@ describe('Action Setup -> Happy path', () => {
 
     it('initializes the github action instance', () => {
       expect(GithubAction).toHaveBeenCalled();
+      expect(GithubAction).toHaveBeenCalledWith(context, expect.objectContaining({
+        github: {
+          branch: 'github-branch-name'
+        }
+      }));
     });
 
     it('runs the unit tests of the project', () => {


### PR DESCRIPTION
## Issues related

Fixes: #14 

### Description

Gets branch name from github context instead of requiring an input parameter